### PR TITLE
addSegment returns and addField enhancments

### DIFF
--- a/lib/hl7/message.js
+++ b/lib/hl7/message.js
@@ -33,7 +33,9 @@ message.prototype.getSegments = function(name) {
 message.prototype.addSegment = function() {
 
   if (arguments.length == 1) {
-    this.segments.push(new segment(arguments[0]));
+    var s = new segment(arguments[0]);
+    this.segments.push(s);
+    return s;
   }
 
   if (arguments.length > 1) {
@@ -42,9 +44,10 @@ message.prototype.addSegment = function() {
       s.addField(arguments[i]);
     }
     this.segments.push(s);
+    return s;
   }
   
-  return s;
+  
 
 }
 

--- a/lib/hl7/message.js
+++ b/lib/hl7/message.js
@@ -43,6 +43,8 @@ message.prototype.addSegment = function() {
     }
     this.segments.push(s);
   }
+  
+  return s;
 
 }
 

--- a/lib/hl7/segment.js
+++ b/lib/hl7/segment.js
@@ -27,8 +27,26 @@ var segment = function() {
 
 }
 
-segment.prototype.addField = function(fieldValue) {
-  this.fields.push(new field(fieldValue));
+segment.prototype.addField = function(fieldValue, position) {
+  //position is optional
+  if(position)
+  {
+    if (this.fields.length > (position - 1)){
+      this.editField(position, fieldValue);
+    }
+    else{
+      currentLength = this.fields.length;
+      do {
+        this.addField("");
+        currentLength = this.fields.length;
+      } while (currentLength <= (position-2));
+      this.addField(fieldValue)
+    }
+  }
+  else
+  {
+    this.fields.push(new field(fieldValue));
+  }
 }
 
 segment.prototype.editField = function(index, fieldValue) {


### PR DESCRIPTION
I've added a couple of features that I needed:

- addSegment now returns a ref to the segment created
- addField now has a second, optional, parameter that will add a field at the provided position.  I needed this because I someone wanted a field in position 18 with nothing before it.  Made my code much neater:

example:

segment = _this.message.addSegment("PID");
              segment.addField(_this.testData.medical_record, 2);
              segment.addField(_this.testData.patient_name.split(', '), 4);
              segment.addField(moment(_this.testData.dob).format("MM/DD/YYY"), 6);
              segment.addField(_this.testData.sex, 8);
              segment.addField(_this.testData.ssn, 17);

outputs:
PID||000418471           ||Day^Dreaming||02/15/84Y||F|||||||||001-77-4021