### PR TITLE
Replaced do...while with simple while in segment.js

### DIFF
--- a/lib/hl7/segment.js
+++ b/lib/hl7/segment.js
@@ -36,10 +36,10 @@ segment.prototype.addField = function(fieldValue, position) {
     }
     else{
       currentLength = this.fields.length;
-      do {
+      while (currentLength <= (position-2)) {
         this.addField("");
         currentLength = this.fields.length;
-      } while (currentLength <= (position-2));
+      }
       this.addField(fieldValue)
     }
   }


### PR DESCRIPTION
When I tried to add a segment and its fields in the following way, the field TQ1.7 is added with value "".
```javascript 
 adt.addSegment(
    'TQ1'
  );
  const tmp = adt.getSegment('TQ1');
  tmp.addField('rptPatrn', 3); //3. repeat-pattern
  tmp.addField('servcDurtn', 6); //6. service-duration
  tmp.addField('201602031000', 7); //7. start-date-time
  tmp.addField('201602031030', 8); //8. end-date-time
  tmp.addField('3344', 13); //occurence-duration
```
The problem is caused due to an extra loop execution in do...while loop.