### PR TITLE
Error handling on segment.getComponent

### DIFF
--- a/lib/hl7/segment.js
+++ b/lib/hl7/segment.js
@@ -62,7 +62,12 @@ segment.prototype.getField = function(index) {
 }
 
 segment.prototype.getComponent = function(fieldIndex, componentIndex) {
-  return this.fields[fieldIndex - 1].value[0][componentIndex - 1].value[0];
+  var field = this.getField(fieldIndex);
+  if (field && field[componentIndex - 1]) {
+    return field[componentIndex - 1].value[0];
+  } else {
+    return '';
+  }
 }
 
 segment.prototype.toString = function(delimiters) {


### PR DESCRIPTION
Avoids having to try / catch for each segment.getComponent call.