### PR TITLE
make tcp client reusable

### DIFF
--- a/lib/client/tcp-client.js
+++ b/lib/client/tcp-client.js
@@ -11,23 +11,39 @@ function TcpClient(host, port) {
   this.parser = new Parser({ segmentSeperator: '\r' });
 }
 
+function sendMessage(msg, callback) {
+  var self = this;
+  var response = "";
+  self.client.on('data', function(data) {
+    response += data.toString();
+    if (response.substring(response.length - 2, response.length) == FS + CR) {
+      var ack = self.parser.parse(response.substring(1, response.length - 2));
+      callback(null, ack);
+      response = "";
+    }
+  });
+  self.client.write(VT + msg.toString() + FS + CR);
+}
+
 TcpClient.prototype.send = function(msg, callback) {
   var self = this;
   try {
-    var client = net.connect({host: this.host, port: this.port}, function() {
-      var response = "";
-      client.on('data', function(data) {
-        response += data.toString();
-        if (response.substring(response.length - 2, response.length) == FS + CR) {
-          var ack = self.parser.parse(response.substring(1, response.length - 2));
-          callback(null, ack);
-          response = "";
-        }
+    if (self.client) {
+      sendMessage.call(self, msg, callback);
+    } else {
+      self.client = net.connect({host: this.host, port: this.port}, function() {
+        sendMessage.call(self, msg, callback);
       });
-      client.write(VT + msg.toString() + FS + CR);
-    });
+    }
   } catch (e) {
     callback(e);
+  }
+}
+
+TcpClient.prototype.close = function() {
+  if (self.client) {
+    self.client.end();
+    delete self.client;
   }
 }
 


### PR DESCRIPTION
I was having trouble sending multiple hl7 messages to dcm4che hl7rcv (https://github.com/dcm4che/dcm4che/blob/master/dcm4che-tool/dcm4che-tool-hl7rcv/README.md)

So, I researched a bit and came across this: https://stackoverflow.com/a/4307337/4905960

Made the tcp client reusable and it worked.