### PR TITLE
Rename variable to fix conflicting fs name

### DIFF
--- a/lib/hl7/parser.js
+++ b/lib/hl7/parser.js
@@ -80,9 +80,9 @@ parser.prototype.parseField = function(s) {
   var f = new field();
 
   if (s.indexOf(this.delimiters.repititionCharacter) != -1) {
-    var fs = s.split(this.delimiters.repititionCharacter);
-    for (var i = 0; i < fs.length; i++) {
-      f.value.push(this.parseField(fs[i]));
+    var _fs = s.split(this.delimiters.repititionCharacter);
+    for (var i = 0; i < _fs.length; i++) {
+      f.value.push(this.parseField(_fs[i]));
     }
   } else {
     var components = s.split(this.delimiters.componentSeperator);


### PR DESCRIPTION
fs is initially declared as the file system module, but in parseField() an internal unrelated variable is also named fs.

Renamed the second, internal variable from fs to _fs to fix this conflict.