### PR TITLE
Add event handling for connecting and closing of new clients

### DIFF
--- a/examples/tcp.js
+++ b/examples/tcp.js
@@ -38,8 +38,17 @@ app.use(function(err, req, res, next) {
 });
 
 
-app.start(7777);
+var server = app.start(7777);
 console.log('tcp interface listening on ' + 7777);
+
+// Special handling for connect and close events on the socket.
+server.on('connect', function (socket) {
+  console.log('Client connected from ' + socket.remoteAddress + ':' + socker.remotePort)
+})
+server.on('close', function (socket) {
+  console.log('Client disconnected from ' + socket.remoteAddress + ':' + socker.remotePort)
+})
+
 ////////////////////SERVER///////////////////
 
 

--- a/lib/server/tcp-server.js
+++ b/lib/server/tcp-server.js
@@ -54,6 +54,11 @@ TcpServer.prototype.start = function(port, encoding, options) {
   this.server = net.createServer(function(socket) {
     var message = "";
 
+    self.emit('connect', socket);
+    socket.on('close', function(hadError) {
+      self.emit('close', socket, hadError)
+    })
+
     socket.on('data', function(data) {
       try {
         message += data.toString();


### PR DESCRIPTION
For debugging/logging purposes I wanted to be able to react when a client connects and disconnects.

I tried some stuff but didn't got it to work, without this patch.

But I think its a viable addition, as with the socket at the connect event, I could add event listeners for all other events on a socket, to do special handling.

If there is a better way todo this, It would be nice if we instead could document this, as I did now with the examples/tcp.js.