### PR TITLE
Use Socket.destroy() in TcpClient.close()

### DIFF
--- a/lib/client/tcp-client.js
+++ b/lib/client/tcp-client.js
@@ -73,6 +73,7 @@ TcpClient.prototype.close = function() {
     self.responseBuffer = "";
     self.awaitingResponse = false;
     self.client.end();
+    self.client.destroy();
     delete self.client;
   }
 }


### PR DESCRIPTION
While testing the library against an HL7-Listener in various scenarios, the following error has occurred:
```
TypeError: Cannot read property 'on' of undefined,
     at Socket.<anonymous> (/.../node_modules/simple-hl7/lib/client/tcp-client.js:29:17),
     at Object.onceWrapper (events.js:277:13),     at Socket.emit (events.js:194:15),
     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1083:10)
```

When using the tcp-client `send()` I have a custom timeout logic in case if the target HL7 listener is unreachable.

So the logic is:
1. Run the tcp-client `send()` function.
2. Wait for 5000ms
3. If no ACK received, use the tcp-client `close()` function.

When I tried to run my code while the HL7-Listener wasn't running, the tcp-client tried to [connect](https://github.com/hitgeek/simple-hl7/blob/2207d04b6b874e8731aa2ff2e50c96314309e203/lib/client/tcp-client.js#L28) to the listener, then the 5000ms timeout was reached, so the tcp-client was [closed](https://github.com/hitgeek/simple-hl7/blob/2207d04b6b874e8731aa2ff2e50c96314309e203/lib/client/tcp-client.js#L75).
But the thing is that the underlined Node.js Socket wasn't disposed and still tried to connect to the HL7-Listener, and when I finally started the listener, [this line](https://github.com/hitgeek/simple-hl7/blob/2207d04b6b874e8731aa2ff2e50c96314309e203/lib/client/tcp-client.js#L29) was reached, where `self.client` is undefined, since it was [disposed before](https://github.com/hitgeek/simple-hl7/blob/2207d04b6b874e8731aa2ff2e50c96314309e203/lib/client/tcp-client.js#L76)  and that caused the error.

In order to avoid the situation, a quick fix would be using the `Socket.destroy()` function, that closes the connection without waiting for the answer from the target server.