### PR TITLE
Update tcp-server.js

### DIFF
--- a/lib/server/tcp-server.js
+++ b/lib/server/tcp-server.js
@@ -25,7 +25,7 @@ function TcpServer(options, handler) {
 
 util.inherits(TcpServer, EventEmitter);
 
-function Req(msg, raw) {
+function Req(msg, raw, socket) {
   this.msg = msg;
   this.raw = raw; 
   this.sender = msg.header.getField(1).length == 1 ?
@@ -38,6 +38,8 @@ function Req(msg, raw) {
 
   this.type = msg.header.getComponent(7, 1).toString();
   this.event = msg.header.getComponent(7, 2).toString();
+  
+  this.socket = socket;
 }
 
 function Res(socket, ack) {
@@ -61,7 +63,7 @@ TcpServer.prototype.start = function(port, encoding, options) {
           var hl7 = self.parser.parse(message.substring(1, message.length - 2));
           var ack = self.createAckMessage(hl7);
 
-          var req = new Req(hl7, message);
+          var req = new Req(hl7, message, socket);
           var res = new Res(socket, ack);
           self.handler(null, req, res);
           message = "";


### PR DESCRIPTION
Pass the socket into the listener, so that it can use that for any decisions it needs to make.
This allows the same listener and server to be used for multiple ports by just doing `app.start(someOtherPort)`