### PR TITLE
Fix failing to spot message end

### DIFF
--- a/lib/client/tcp-client.js
+++ b/lib/client/tcp-client.js
@@ -28,6 +28,21 @@ TcpClient.prototype.connect = function(callback) {
   self.client = net.connect({host: self.host, port: self.port}, function() {
     self.client.on('data', function(data) {
       self.responseBuffer += data.toString();
+
+      /*
+      'Sometimes' the responseBuffer contains things like FS or CR, and so 
+      self.responseBuffer.substring() stops copying early, and the compare to FS+CR fails
+      So try a real parse, see if it's a response.
+      */
+      var _parsed = false;
+      var _ackish = false;
+      try{
+        const ackish = self.parser.parse(self.responseBuffer.substring(1, self.responseBuffer.length - 1));
+        _parsed = true;
+      }catch(e){
+        console.log('ackish',e)
+      }
+
       if (self.responseBuffer.substring(self.responseBuffer.length - 2, self.responseBuffer.length) == FS + CR) {
         var ack = self.parser.parse(self.responseBuffer.substring(1, self.responseBuffer.length - 2));
         self.callback(null, ack);


### PR DESCRIPTION
We discovered that sometimes we were not spotting the end of HL7 message sequence due to unexpected truncaton.

This fixes that by, in addition to existing EOM check, trying a real parse.