### PR TITLE
FIX getComponent can't get data if there are repetitions

### DIFF
--- a/lib/hl7/segment.js
+++ b/lib/hl7/segment.js
@@ -89,6 +89,9 @@ segment.prototype.getField = function(index, repeatIndex) {
 segment.prototype.getComponent = function(fieldIndex, componentIndex, subComponentIndex) {
   if (this.fields.length >= fieldIndex) {
     var components = this.fields[fieldIndex - 1].value[0];
+
+    if(components.value) components = components.value[0];
+
     if (components.length >= componentIndex) {
       var component = components[componentIndex - 1]
       if (subComponentIndex) {


### PR DESCRIPTION
As mentioned in this issue: [HERE](https://github.com/hitgeek/simple-hl7/issues/77)

Fields with repetitions are not caught from getComponent function.
I made a simple fix checking if there's a subvalue containing the components array.